### PR TITLE
fix: update plugin ID mappoing for shotfunpanel vissibility

### DIFF
--- a/python/tk_cinema/constant_apps.py
+++ b/python/tk_cinema/constant_apps.py
@@ -36,7 +36,7 @@ menu_prebuild = [
      ["Load...", "3279052", "main"],
      ["Separator", "0", "separator"],
      ["Scene Breakdown...", "1506973", "main"],
-     ["Shotgun Panel...", "2399777", "main"],
+     ["Flow Production Tracking Panel...", "2014075", "main"],
      # ["Snapshot History...", "3313077", "main"],
      ["Sync Frame Range with Shotgun", "3366874", "main"],
      ["Separator", "0", "separator"],

--- a/startup/shotgun.pyp
+++ b/startup/shotgun.pyp
@@ -188,15 +188,21 @@ def register_plugins():
     c4d.plugins.RegisterMessagePlugin(id=15151510, str="", info=0, dat=SceneChangeEvent())
 
     for item in engine.import_module("tk_cinema").constant_apps.menu_prebuild:
+        logger.debug(f"Processing menu item: {item}")
         if not "separator" in item[-1]:
-            c4d.plugins.RegisterCommandPlugin(
-                id=int(item[-2]),
-                str=item[0],
-                info=c4d.PLUGINFLAG_HIDEPLUGINMENU,
-                help='',
-                icon=None,
-                dat=callbackPlugin(callback=item[0])
-            )
+            try:
+                plugin_id = int(item[-2])
+                c4d.plugins.RegisterCommandPlugin(
+                    id=plugin_id,
+                    str=item[0],
+                    info=c4d.PLUGINFLAG_HIDEPLUGINMENU,
+                    help='',
+                    icon=None,
+                    dat=callbackPlugin(callback=item[0])
+                )
+                logger.debug(f"Registered: {item[0]} with ID {plugin_id}")
+            except Exception as e:
+                logger.debug(f"Failed to register: {item[0]} with error: {e}")
 
 if __name__ == '__main__':
     register_plugins()


### PR DESCRIPTION
### Problem
After the rebranding to FPTR, the panel stopped appearing in the Cinema 4D custom menu. This issue was caused by a mismatch in the dynamically generated plugin ID.

### Solution&Changes
- Updated the plugin ID mapping in the code to use the correct ID: `2014075`
- Enhanced logging in the plugin registration block
